### PR TITLE
Add esbuild linux binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3"
+        "react-router-dom": "^7.6.3",
+        "@esbuild/linux-x64": "0.21.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.6.3",
+    "@esbuild/linux-x64": "0.21.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Summary
- fix Netlify build failing from missing `@esbuild/linux-x64`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fc31d4c4c832093bcc5b85c410ab0