### PR TITLE
Fix Netlify missing lightningcss module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.3",
-        "@esbuild/linux-x64": "0.21.5"
+        "@esbuild/linux-x64": "0.21.5",
+        "lightningcss-linux-x64-gnu": "1.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
-    "@esbuild/linux-x64": "0.21.5"
+    "@esbuild/linux-x64": "0.21.5",
+    "lightningcss-linux-x64-gnu": "1.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Summary
- install `lightningcss-linux-x64-gnu` so the Linux binary is available during builds

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc6946e9883208fc813362f1cb96e